### PR TITLE
Update Getting Started with Gatsby and Nextjs Docs

### DIFF
--- a/examples/stories/src/tutorial/getting-started/ssg/gatsby.mdx
+++ b/examples/stories/src/tutorial/getting-started/ssg/gatsby.mdx
@@ -8,11 +8,11 @@ tags:
   - gatsby
 ---
 
-Below, we go over how to add a `component-controls` documentation site to both [new](#new-project) and [existing](#existing-gatsby-project) gatsby projects.
+Below, we go over how to add a `component-controls` documentation site to [new Gatsby projects](#new-project), [existing React projects](#existing--non-gatsby--react-project), and [existing Gatsby projects](<(#existing-gatsby-project)>).
 
 You can find a [git repo](https://github.com/atanasster/gatsby-controls-starter) and a [live site](https://gatsby-controls-starter.netlify.app/).
 
-## New project 
+## New project
 
 Create a new folder:
 
@@ -26,7 +26,7 @@ Initialize the project:
 yarn init
 ```
 
-Add gatsby and its dependencies:
+Add Gatsby and its dependencies:
 
 ```sh
 yarn add gatsby react react-dom
@@ -41,7 +41,17 @@ yarn add gatsby react react-dom
 
 ```
 
-The remaining steps are the same as for an existing gatsby project.
+The remaining steps are the same as for [existing Gatsby projects](#existing-gatsby-project).
+
+## Existing (non-Gatsby) React project
+
+All you have to do is add Gatsby as a dependency:
+
+```sh
+yarn add gatsby
+```
+
+Then follow the steps for [existing Gatsby projects](#existing-gatsby-project).
 
 ## Existing Gatsby project
 
@@ -54,6 +64,7 @@ yarn add @component-controls/gatsby-theme-stories
 ### Configure theme
 
 Create a `gatsby-config.js` file in your project's home directory:
+
 ```js:title=gatsby-config.js
 module.exports = {
   plugins: [

--- a/examples/stories/src/tutorial/getting-started/ssg/nextjs.mdx
+++ b/examples/stories/src/tutorial/getting-started/ssg/nextjs.mdx
@@ -8,7 +8,7 @@ tags:
   - nextjs
 ---
 
-Below, we go over how to add a `component-controls` documentation site to both [new](#new-project) and [existing](#existing-nextjs-project) nextjs projects.
+Below, we go over how to add a `component-controls` documentation site to [new Nextjs projects](#new-project), [existing React projects](#existing--non-nextjs--react-project), and [existing Nextjs projects](#existing-nextjs-project).
 
 You can find a [git repo](https://github.com/atanasster/nextjs-controls-starter) and a [live site](https://nextjs-controls-starter.netlify.app/).
 
@@ -23,7 +23,7 @@ git clone https://github.com/atanasster/nextjs-controls-starter my-nextjs-projec
 
 ## New project
 
-If you want to create and configure a nextjs documentation site from scratch instead of cloning the starter repo, the following steps are required:
+If you want to create and configure a Nextjs documentation site from scratch instead of cloning the starter repo, the following steps are required:
 
 ```sh
 mkdir my-nextjs-project && cd my-nextjs-project
@@ -57,10 +57,19 @@ yarn add --dev typescript @types/react @types/node
 
 ```
 
-The remaining steps are the same as for an existing nextjs project.
+The remaining steps are the same as for [existing Nextjs projects](#existing-nextjs-project).
 
+## Existing (non-Nextjs) React project
 
-## Existing nextjs project
+All you have to do is add Nextjs as a dependency:
+
+```sh
+yarn add next
+```
+
+Then follow the steps for [existing Nextjs projects](#existing-nextjs-project).
+
+## Existing Nextjs project
 
 ### Add component-controls
 


### PR DESCRIPTION
Update the Getting Started docs for gatsby and nextjs to differentiate between how users can add component-controls to new projects, existing React projects, and existing nextjs/gatsby projects.