### PR TITLE
Fix spacing in page header

### DIFF
--- a/ui/blocks/src/ComponentStats/ComponentStats.tsx
+++ b/ui/blocks/src/ComponentStats/ComponentStats.tsx
@@ -15,14 +15,18 @@ export const ComponentStats: FC<{
   const stats = component.fileInfo?.sloc;
   return stats ? (
     <Box variant={`componentstats.${variant}`} {...rest}>
-      <Value sx={{ mx: 1 }} label="source lines:" value={stats.source} />
+      <Value label="source lines:" value={stats.source} />
       <Value
         label="comments %:"
-        value={
-          stats.source ? Math.round((100 * stats.comment) / stats.source) : 0
-        }
+        value={(stats.source
+          ? Math.round((100 * stats.comment) / stats.source)
+          : 0
+        ).toString()}
+        sx={{ ml: 2 }}
       />
-      {!!stats.todo && <Value label="todo lines:" value={stats.todo} />}
+      {!!stats.todo && (
+        <Value label="todo lines:" value={stats.todo} sx={{ ml: 2 }} />
+      )}
     </Box>
   ) : null;
 };

--- a/ui/components/src/ThemeContext/theme.ts
+++ b/ui/components/src/ThemeContext/theme.ts
@@ -491,6 +491,7 @@ export const theme: ControlsTheme = {
         display: 'flex',
         flexDirection: ['column', 'row'],
         alignItems: ['flex-end', 'baseline'],
+        justifyContent: 'space-between',
       },
     },
   },


### PR DESCRIPTION
Resolves #23 

1. Add a margin to the bottom row of the page header `<Container />`. 
2. Add a `justifyContent: spaceBetween` to the top row
Before:
![image](https://user-images.githubusercontent.com/12395992/110891538-2e79d480-82c0-11eb-9677-7def71ac738c.png)
After:
![image](https://user-images.githubusercontent.com/12395992/110891573-44879500-82c0-11eb-8812-4b7d9e796a5e.png)
